### PR TITLE
data_source page: use really data_source

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -35,11 +35,7 @@ activate :directory_indexes
 
 activate :data_source do |c|
   c.root  = "https://newtablab.com/test"
-  c.sources = [
-    { alias: "testdb",
-      path: "db.json",
-      type: :json }
-  ]
+  c.files = { "db.json" => "my_remote_json" }
 end
 
 configure :build do

--- a/source/pages/json_data_source.en.html.erb
+++ b/source/pages/json_data_source.en.html.erb
@@ -1,7 +1,7 @@
 ---
 layout: "layout-en"
 title: Remote JSON data with data_source
-description: Data from data/food.json & data/people.yml See source/statics/js/custom.js.
+description: Data from https://newtablab.com/test/db.json. See source/pages/json_data_source.*.html.erb and config.rb.
 ---
 <% content_for :lang_url do %>/tr/json_data_source/<% end %>
 <% content_for :lang_title do %>Türkçe<% end %>
@@ -17,15 +17,15 @@ description: Data from data/food.json & data/people.yml See source/statics/js/cu
             <%= partial "partials/_leftmenu-en" %>
         </div>
         <div class="col-lg-9 order-1 order-lg-2">
-            <p>Data from <code>data/food.json</code> & <code>data/people.yml</code> See <code>source/statics/js/custom.js</code>.</p>
+            <p>Data from <code>https://newtablab.com/test/db.json</code>.<br>See <code>source/pages/json_data_source.*.html.erb</code> and <code>config.rb</code>.</p>
             <hr>
             <ol>
-                <% data.food.fruits.each do |z| %>
+                <% data.my_remote_json.fruits.each do |z| %>
                 <li><%= z %></li>
                 <% end %>
             </ol>
             <ul>
-                <% data.people.friends.each do |f| %>
+                <% data.my_remote_json.people.each do |f| %>
                 <li><%= f %></li>
                 <% end %>
             </ul>

--- a/source/pages/json_data_source.tr.html.erb
+++ b/source/pages/json_data_source.tr.html.erb
@@ -1,7 +1,7 @@
 ---
 layout: "layout-tr"
 title: Remote JSON data with data_source
-description: Data from data/food.json & data/people.yml See source/statics/js/custom.js.
+description: Data from https://newtablab.com/test/db.json. See source/pages/json_data_source.*.html.erb and config.rb.
 ---
 <% content_for :lang_url do %>/en/json_data_source/<% end %>
 <% content_for :lang_title do %>English<% end %>
@@ -17,15 +17,15 @@ description: Data from data/food.json & data/people.yml See source/statics/js/cu
             <%= partial "partials/_leftmenu-tr" %>
         </div>
         <div class="col-lg-9 order-1 order-lg-2">
-            <p>Data from <code>data/food.json</code> & <code>data/people.yml</code> See <code>source/statics/js/custom.js</code>.</p>
+            <p>Data from <code>https://newtablab.com/test/db.json</code>.<br>See <code>source/pages/json_data_source.*.html.erb</code> and <code>config.rb</code>.</p>
             <hr>
             <ol>
-                <% data.food.fruits.each do |z| %>
+                <% data.my_remote_json.fruits.each do |z| %>
                 <li><%= z %></li>
                 <% end %>
             </ol>
             <ul>
-                <% data.people.friends.each do |f| %>
+                <% data.my_remote_json.people.each do |f| %>
                 <li><%= f %></li>
                 <% end %>
             </ul>


### PR DESCRIPTION
Hi Tarik. I thought I would help a little. My first proposition for your Boilerplate.

The `data_source` example page uses plain [Middleman Data File](https://middlemanapp.com/advanced/data-files/) feature instead of remote file via [middleman-data_source](https://github.com/stevenosloan/middleman-data_source) gem. This pull fixes this.