### PR TITLE
local-data feature reinstated on new page

### DIFF
--- a/data/food.json
+++ b/data/food.json
@@ -1,7 +1,7 @@
 {
     "fruits": [
-      "Apple",
-      "Orange",
-      "Banana"
+      "Peach",
+      "Cherry",
+      "Blueberry"
     ]
 }

--- a/data/people.yml
+++ b/data/people.yml
@@ -1,4 +1,4 @@
 friends:
-  - Tom
-  - Dick
-  - Harry
+  - Abbie
+  - Barbara
+  - Camille

--- a/source/pages/json_local_data.en.html.erb
+++ b/source/pages/json_local_data.en.html.erb
@@ -1,0 +1,34 @@
+---
+layout: "layout-en"
+title: Local data with Middleman data-folder feature
+description: Data from data/food.json & data/people.yml. See source/pages/json_local_data.*.html.erb.
+---
+<% content_for :lang_url do %>/tr/json_local_data/<% end %>
+<% content_for :lang_title do %>Türkçe<% end %>
+<% content_for :subm1_show do %>show<% end %>
+
+<div class="container" id="content">
+    <div class="row">
+        <div class="col-12 order-0 order-lg-0">
+            <h1><%= current_page.data.title %></h1>
+            <hr>
+        </div>
+        <div class="col-lg-3 order-2 order-lg-1">
+            <%= partial "partials/_leftmenu-en" %>
+        </div>
+        <div class="col-lg-9 order-1 order-lg-2">
+            <p>Data from <code>data/food.json</code> & <code>data/people.yml</code> See <code>source/pages/json_local_data.*.html.erb</code>.</p>
+            <hr>
+            <ol>
+                <% data.food.fruits.each do |z| %>
+                <li><%= z %></li>
+                <% end %>
+            </ol>
+            <ul>
+                <% data.people.friends.each do |f| %>
+                <li><%= f %></li>
+                <% end %>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/source/pages/json_local_data.tr.html.erb
+++ b/source/pages/json_local_data.tr.html.erb
@@ -1,0 +1,34 @@
+---
+layout: "layout-tr"
+title: Local data with Middleman data-folder feature
+description: Data from data/food.json & data/people.yml. See source/pages/json_local_data.*.html.erb.
+---
+<% content_for :lang_url do %>/en/json_local_data/<% end %>
+<% content_for :lang_title do %>English<% end %>
+<% content_for :subm1_show do %>show<% end %>
+
+<div class="container" id="content">
+    <div class="row">
+        <div class="col-12 order-0 order-lg-0">
+            <h1><%= current_page.data.title %></h1>
+            <hr>
+        </div>
+        <div class="col-lg-3 order-2 order-lg-1">
+            <%= partial "partials/_leftmenu-tr" %>
+        </div>
+        <div class="col-lg-9 order-1 order-lg-2">
+            <p>Data from <code>data/food.json</code> & <code>data/people.yml</code> See <code>source/pages/json_local_data.*.html.erb</code>.</p>
+            <hr>
+            <ol>
+                <% data.food.fruits.each do |z| %>
+                <li><%= z %></li>
+                <% end %>
+            </ol>
+            <ul>
+                <% data.people.friends.each do |f| %>
+                <li><%= f %></li>
+                <% end %>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/source/partials/_leftmenu-en.html.erb
+++ b/source/partials/_leftmenu-en.html.erb
@@ -6,6 +6,7 @@
             <div class="collapse <%= yield_content :subm1_show %>" id="submenu1" aria-expanded="false">
                 <ul class="flex-column nav">
                     <%= nav_item_link_to 'JSON with data_source', '/en/json_data_source/', :class => 'nav-link'  %>
+                    <%= nav_item_link_to 'JSON with Middleman data', '/en/json_local_data/', :class => 'nav-link'  %>
                     <li class="nav-item">
                         <a class="nav-link collapsed" href="#submenu1sub1" data-toggle="collapse" data-target="#submenu1sub1">Submenu Sub</a>
                         <div class="collapse <%= yield_content :subm1a_show %>" id="submenu1sub1" aria-expanded="false">

--- a/source/partials/_leftmenu-tr.html.erb
+++ b/source/partials/_leftmenu-tr.html.erb
@@ -6,6 +6,7 @@
             <div class="collapse <%= yield_content :subm1_show %>" id="submenu1" aria-expanded="false">
                 <ul class="flex-column nav">
                     <%= nav_item_link_to 'JSON with data_source', '/tr/json_data_source/', :class => 'nav-link'  %>
+                    <%= nav_item_link_to 'JSON with Middleman data', '/tr/json_local_data/', :class => 'nav-link'  %>
                     <li class="nav-item">
                         <a class="nav-link collapsed" href="#submenu1sub1" data-toggle="collapse" data-target="#submenu1sub1">Altmenü Alt</a>
                         <div class="collapse <%= yield_content :subm1a_show %>" id="submenu1sub1" aria-expanded="false">


### PR DESCRIPTION
Previous pull fixed data_source example, so this reinstates local data example: new page in menu, using existing files: /data/food.json and /data/people.yml. For the sake of variety, I changed the people and fruit names in JSON/YML files, just to make sure you’re not seeing data from remote files used in other examples.

(I see there are new updates in your repo, will update/rebase mine today.)